### PR TITLE
workaround clipper changing ring order of multipolygons with holes

### DIFF
--- a/src/VectorTileReader/VectorTileFeature.cs
+++ b/src/VectorTileReader/VectorTileFeature.cs
@@ -3,17 +3,20 @@ using Mapbox.VectorTile.Geometry;
 using System;
 
 
-namespace Mapbox.VectorTile {
+namespace Mapbox.VectorTile
+{
 
 
-	public class VectorTileFeature {
+	public class VectorTileFeature
+	{
 
 
 		/// <summary>
 		/// Initialize VectorTileFeature
 		/// </summary>
 		/// <param name="layer">Parent <see cref="VectorTileLayer"/></param>
-		public VectorTileFeature(VectorTileLayer layer, uint? clipBuffer = null, float scale = 1.0f) {
+		public VectorTileFeature(VectorTileLayer layer, uint? clipBuffer = null, float scale = 1.0f)
+		{
 			_layer = layer;
 			_clipBuffer = clipBuffer;
 			_scale = scale;
@@ -49,7 +52,8 @@ namespace Mapbox.VectorTile {
 		public List<List<Point2d<T>>> Geometry<T>(
 			uint? clipBuffer = null
 			, float? scale = null
-		) {
+		)
+		{
 
 			// parameters passed to this method override parameters passed to the constructor
 			if (_clipBuffer.HasValue && !clipBuffer.HasValue) { clipBuffer = _clipBuffer; }
@@ -58,7 +62,8 @@ namespace Mapbox.VectorTile {
 			// TODO: how to cache 'finalGeom' without making whole class generic???
 			// and without using an object (boxing) ???
 			List<List<Point2d<T>>> finalGeom = _cachedGeometry as List<List<Point2d<T>>>;
-			if (null != finalGeom && scale==_previousScale) {
+			if (null != finalGeom && scale == _previousScale)
+			{
 				return finalGeom;
 			}
 
@@ -69,8 +74,40 @@ namespace Mapbox.VectorTile {
 				, GeometryCommands
 				, scale.Value
 			);
-			if (clipBuffer.HasValue) {
-				geom = UtilGeom.ClipGeometries(geom, GeometryType, (long)_layer.Extent, clipBuffer.Value, scale.Value);
+			if (clipBuffer.HasValue)
+			{
+				// HACK !!!
+				// work around a 'feature' of clipper where the ring order gets mixed up
+				// with multipolygons containing holes
+				if (geom.Count < 2 || GeometryType != GeomType.POLYGON)
+				{
+					// work on points, lines and single part polygons as before
+					geom = UtilGeom.ClipGeometries(geom, GeometryType, (long)_layer.Extent, clipBuffer.Value, scale.Value);
+				}
+				else
+				{
+					// process every ring of a polygon in a separate loop
+					List<List<Point2d<long>>> newGeom = new List<List<Point2d<long>>>();
+					for (int i = 0; i < geom.Count; i++)
+					{
+						List<Point2d<long>> part = geom[i];
+						List<List<Point2d<long>>> tmp = new List<List<Point2d<long>>>();
+						// flip order of inner rings to look like outer rings
+						bool isInner = signedPolygonArea(part) >= 0;
+						if (isInner) { part.Reverse(); }
+						tmp.Add(part);
+						tmp = UtilGeom.ClipGeometries(tmp, GeometryType, (long)_layer.Extent, clipBuffer.Value, scale.Value);
+						// ring was completely outside of clip border
+						if (0 == tmp.Count)
+						{
+							continue;
+						}
+						// flip winding order of inner rings back
+						if (isInner) { tmp[0].Reverse(); }
+						newGeom.Add(tmp[0]);
+					}
+					geom = newGeom;
+				}
 			}
 
 			//HACK: use 'Scale' to convert to <T> too
@@ -83,6 +120,21 @@ namespace Mapbox.VectorTile {
 			return finalGeom;
 		}
 
+
+		private float signedPolygonArea(List<Point2d<long>> vertices)
+		{
+			int num_points = vertices.Count - 1;
+			float area = 0;
+			for (int i = 0; i < num_points; i++)
+			{
+				area +=
+					(vertices[i + 1].X - vertices[i].X) *
+					(vertices[i + 1].Y + vertices[i].Y) / 2;
+			}
+			return area;
+		}
+
+
 		/// <summary>Tags to resolve properties https://github.com/mapbox/vector-tile-spec/tree/master/2.1#44-feature-attributes</summary>
 		public List<int> Tags { get; set; }
 
@@ -91,13 +143,16 @@ namespace Mapbox.VectorTile {
 		/// Get properties of this feature. Throws exception if there is an uneven number of feature tag ids
 		/// </summary>
 		/// <returns>Dictionary of this feature's properties</returns>
-		public Dictionary<string, object> GetProperties() {
+		public Dictionary<string, object> GetProperties()
+		{
 
-			if (0 != Tags.Count % 2) {
+			if (0 != Tags.Count % 2)
+			{
 				throw new Exception(string.Format("Layer [{0}]: uneven number of feature tag ids", _layer.Name));
 			}
 			Dictionary<string, object> properties = new Dictionary<string, object>();
-			for (int i = 0; i < Tags.Count; i += 2) {
+			for (int i = 0; i < Tags.Count; i += 2)
+			{
 				properties.Add(_layer.Keys[Tags[i]], _layer.Values[Tags[i + 1]]);
 			}
 			return properties;
@@ -109,15 +164,19 @@ namespace Mapbox.VectorTile {
 		/// </summary>
 		/// <param name="key">Name of the property to request</param>
 		/// <returns>Value of the requested property</returns>
-		public object GetValue(string key) {
+		public object GetValue(string key)
+		{
 
 			var idxKey = _layer.Keys.IndexOf(key);
-			if (-1 == idxKey) {
+			if (-1 == idxKey)
+			{
 				throw new Exception(string.Format("Key [{0}] does not exist", key));
 			}
 
-			for (int i = 0; i < Tags.Count; i++) {
-				if (idxKey == Tags[i]) {
+			for (int i = 0; i < Tags.Count; i++)
+			{
+				if (idxKey == Tags[i])
+				{
 					return _layer.Values[Tags[i + 1]];
 				}
 			}


### PR DESCRIPTION
Sometimes clipper changes order of outer and inner rings within a complex multipolygon with holes geometry.
This screws rendereing in Unity.